### PR TITLE
Ajouter un bouton pour copier les blocs de code.

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<script src="/fr/assets/js/copyBtn.js"></script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -17,3 +17,23 @@
   background-color: #fff3cd;
   border-color: #ffeeba;
 }
+
+.copyBtn {
+  float: right;
+  position: relative;
+  cursor: pointer;
+  right: 15px;
+  border: 1px solid black;
+  border-radius: 3px;
+  background-color: rgba(0,0,0,0%);
+  color: black;
+  padding: 3px;
+  font-size: 11px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .copyBtn {
+    color: white;
+    border-color: white;
+  }
+}

--- a/assets/js/copyBtn.js
+++ b/assets/js/copyBtn.js
@@ -1,0 +1,19 @@
+function copy(elem, btn) {
+    let r = document.createRange();
+    r.selectNode(elem);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(r);
+    document.execCommand('copy');
+    btn.innerText = document.documentElement.lang === 'fr' ? "Copié !" : "Copied!";
+    setTimeout(() => { btn.innerText = document.documentElement.lang === 'fr' ? "Copier" : "Copy" }, 5000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('div.highlight').forEach(elem => {
+        const copyBtn = document.createElement('button');
+        copyBtn.addEventListener('click', () => copy(elem, copyBtn));
+        copyBtn.classList.add('copyBtn');
+        copyBtn.innerText = document.documentElement.lang === 'fr' ? "Copier" : "Copy";
+        elem.parentNode.insertBefore(copyBtn, elem);
+    });
+});


### PR DESCRIPTION
Je n'ai pas trouvé de lib très efficace pour faire cela. Je n'ai pas cherché très fort non plus, étant donné la faible charge de travail que cela demande d'avoir un truc custom. 

Qui plus est, avec cette solution, nulle besoin de modifier le contenu de la doc, le thème se charge de tout.
